### PR TITLE
exclude returns empty

### DIFF
--- a/source/models-tutorial.rst
+++ b/source/models-tutorial.rst
@@ -476,7 +476,7 @@ the exclude method - equal to all-filter::
 
 returns::
 
-    [<CD: Kid A by Radiohead, 2010>]
+    []
 
 Now on to the lookups:
 


### PR DESCRIPTION
I found when I pasted snippets from text.

```
In [13]: CD.objects.exclude(title='OK Computer')
Out[13]: <QuerySet []>
```