### PR TITLE
Fix spelling

### DIFF
--- a/source/chapter3.rst
+++ b/source/chapter3.rst
@@ -313,7 +313,7 @@ But there's a simpler way:
 
 .. sourcecode:: python
 
-    from django.shortcuts import renders
+    from django.shortcuts import render
 
     def hello_world(request):
 	    return render(request,"hello_world.html", {"username": "Monty Python"})


### PR DESCRIPTION
`from django.shortcuts import render` instead of `from django.shortcuts import renders` in line 316.